### PR TITLE
Linking dependency on data-story-org/core

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,5 @@
 /docs               export-ignore
 /.github            export-ignore
 /.editorconfig      export-ignore
+
+package.json filter=changeToGitVersion

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "lodash": "^4.17.21",		
         "@babel/plugin-proposal-decorators": "^7.12.1",
         "@babel/plugin-transform-modules-commonjs": "^7.13.8",
-        "@data-story-org/core": "link../core",
+        "@data-story-org/core": "data-story-org/core",
         "@emotion/react": "^11.1.5",
         "@emotion/styled": "^11.3.0",
         "@projectstorm/react-diagrams": "^6.0.2",


### PR DESCRIPTION
# Prerequisites

To develop gui without constant need in syncing dependencies for getting latest commits in the core repository, default node link feature will be a perfect solution. There s also a [yanc](https://github.com/whitecolor/yalc), [which tries to solve that problem](https://www.viget.com/articles/how-to-use-local-unpublished-node-packages-as-project-dependencies/), but in fact It's just a wrapper around default link feature with lock files what really will force us to update linked dependency manually.

## Solution

The best solution I see is always have dependency on github core repo in the source control, but use linked dependency for real. What we want is to make git ignore our linked dependency line in package.json. That's pretty simple and straightforward, we will just create filter named "changeToGitVersion" and place it on our package.json in gitattributes

```shell
$ git config  filter.changeToGitVersion.clean 'sed "s/\"@data-story-org\/core\": .*/\"@data-story-org\/core\": \"data-story-org\/core\",/"'
$ git config  filter.changeToGitVersion.smudge 'sed "s/\"@data-story-org\/core\": .*/\"@data-story-org\/core\": \"link:..\/core\",/"'
$ git config  filter.changeToGitVersion.required true
```

Filtering with sed will work just like an find and replace (s/foo/bar/ mean "find foo and replace with bar"). After this changes even if we add package.json using git add, github core dependenciy will remain on source control and we still could use local link feature.

## Testing

Tested on my local machine, all works as expected. Source control shows nothing but I still got possibility to use linked core repo.
![2021-07-13_15-32-39](https://user-images.githubusercontent.com/49302467/125452819-1eedc324-1aaf-4e55-ae2d-4ca2d546e3d9.png)
![magit](https://user-images.githubusercontent.com/49302467/125453571-bf00b8c7-6ac5-466a-93b3-0f0f739e33cc.png)
![screnshot](https://user-images.githubusercontent.com/49302467/125460089-7323b888-bce4-42e5-ac62-cae821fc29cf.png)
