### PR TITLE
Fully remove docs/ dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --config=node_modules/laravel-mix/setup/webpack.config.js",
     "test": "jest --testPathIgnorePatterns=.*e2e.test.*",
     "test:e2e": "jest --passWithNoTests --detectOpenHandles -c jest.e2e.config.js",
-    "github-pages:deploy": "gh-pages -d docs"
+    "github-pages:deploy": "gh-pages -d public"
   },
   "dependencies": {
     "@data-story-org/core": "data-story-org/core#master",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,5 +13,4 @@ mix
   // fonts loading
   .setResourceRoot('../')
   .copy('fonts', 'dist/fonts')
-  .copy('dist', 'public') // easy dev access
-  .copy('public', 'docs');
+  .copy('dist', 'public');


### PR DESCRIPTION
# Changes
Since we really don't need docs dir, let's remove that useless steps of copying something to it, and just publish public to github-pages