### PR TITLE
Get rid of a annoying lint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,14 @@
     "plugin:jest/recommended"
   ],
   "rules": {
-    "@typescript-eslint/ban-types": "warn"
-  }
+    "@typescript-eslint/ban-types": "warn",
+  },
+  "overrides": [
+    {
+      "files": ["**/*.tsx"],
+      "rules": {
+        "react/prop-types": "off",
+      }
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
   ],
   "rules": {
     "@typescript-eslint/ban-types": "warn",
+    "@typescript-eslint/ban-ts-comment": "warn",
   },
   "overrides": [
     {

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Format with prettier
         run: yarn format
 
-      # - name: Fix all fixable eslint warnings
-      #   run: npm run lint:quiet:fix
+      - name: Fix all fixable eslint warnings
+        run: yarn lint:quiet:fix
 
       # - name: Get all unfixable eslint errors
       #   uses: wearerequired/lint-action@v1

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/dist/js/index.js": "/dist/js/index.js",
-    "/dist/css/app.css": "/dist/css/app.css"
+  "/dist/js/index.js": "/dist/js/index.js",
+  "/dist/css/app.css": "/dist/css/app.css"
 }

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,5 +1,4 @@
 {
-  "/dist/js/index.js": "/dist/js/index.js",
-  "/dist/css/app.css": "/dist/css/app.css",
-  "/docs/index.html": "/docs/index.html"
+    "/dist/js/index.js": "/dist/js/index.js",
+    "/dist/css/app.css": "/dist/css/app.css"
 }

--- a/src/diagram/models/DiagramModel.ts
+++ b/src/diagram/models/DiagramModel.ts
@@ -41,7 +41,7 @@ export default class DiagramModel extends DefaultDiagramModel {
     // The default react-diagrams format
     const layered = super.serialize();
 
-    let simplified = {
+    const simplified = {
       // Provide links and nodes as simple arrays
       nodes: Object.values(layered.layers[1].models),
       links: Object.values(layered.layers[0].models),
@@ -218,7 +218,7 @@ export default class DiagramModel extends DefaultDiagramModel {
     // Transfer node features
     serverDiagram.nodes.forEach((serverNode) => {
       // TODO how use type node: NodeModel here?
-      let node: any = this.getNode(serverNode.id);
+      const node: any = this.getNode(serverNode.id);
       node.features = serverNode.features;
     });
 
@@ -233,7 +233,7 @@ export default class DiagramModel extends DefaultDiagramModel {
         return port.features;
       })
       .forEach((port) => {
-        let allLinks = Object.values(
+        const allLinks = Object.values(
           (this.layers[0] as any).models,
         );
 

--- a/src/store/RootStore.ts
+++ b/src/store/RootStore.ts
@@ -183,7 +183,7 @@ export class Store {
 
   setDiagramLocked(locked: boolean) {
     this.diagram.engine.model.setLocked(locked);
-    let state = this.diagram.engine
+    const state = this.diagram.engine
       .getStateMachine()
       .getCurrentState();
     if (state.dragCanvas !== undefined) {


### PR DESCRIPTION
# Prerequisites
Although a lot of properly typed components which types being recognized by ts compiler and my IDE, react/prop-types rules often reports that prop is missing validations. Like here

![image](https://user-images.githubusercontent.com/49302467/129440000-9ba87e01-b877-493a-bb55-b4cbf40c253b.png)

Running my eyes through this [related issue](https://github.com/yannickcr/eslint-plugin-react/issues/2353) I can say that this happens because eslint-plugin-react doesn't handle FC type properly. Since the authors of repo not really interested in adding proper support, and all FC props types are perfectly handled by just typescript, I decided to disable react/prop-types rule.

Here's some strange answer by one of the main contributors

![image](https://user-images.githubusercontent.com/49302467/129440235-959fb496-09ed-498f-81fa-34344bd4d9be.png)
 