### PR TITLE
Fix errors with jest unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,19 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts'],
   transformIgnorePatterns: [
-    // '/node_modules/?!(@data-story-org/core).+js$',
     '/node_modules/(?!@data-story-org/core)',
   ],
   transform: {
     '\\.js$': 'babel-jest',
+  },
+  // FIXME remove this when jest will
+  // support package.json "exports"
+  // https://github.com/facebook/jest/issues/9771
+  // https://github.com/facebook/jest/issues/10422
+  moduleNameMapper: {
+    '^@data-story-org/core/(.*)$':
+      '@data-story-org/core/lib/src/$1',
   },
 };


### PR DESCRIPTION
# Prerequisites

It seems like jest doesn't support resolving package.json exports field, so as temporary workaround unless jest implements this support there will be module name's mapper for the test suite that converts imports names as shown below 
```js
import "@data-story-org/core/utils" ==> import "@data-story-org/core/lib/src/utils"
```
## Related issues
https://github.com/facebook/jest/issues/9771
https://github.com/facebook/jest/issues/10422