### PR TITLE
DataStory widget

### DIFF
--- a/src/clients/APIClient.ts
+++ b/src/clients/APIClient.ts
@@ -6,7 +6,7 @@ import {
   RunResult,
 } from './ClientInterface';
 import { parse } from 'flatted';
-import { SerializedReactDiagram } from '../types';
+import { SerializedReactDiagram, Story } from '../types';
 
 export class APIClient implements ClientInterface {
   public root = 'http://localhost:3000'; // https://data-story-server.herokuapp.com
@@ -42,10 +42,9 @@ export class APIClient implements ClientInterface {
     throw 'Not implemented';
   }
 
-  save(name, model) {
+  save(story: Story) {
     return axios.post(this.root + '/save', {
-      name,
-      model: model.toJson(),
+      story,
     });
   }
 }

--- a/src/clients/APIClient.ts
+++ b/src/clients/APIClient.ts
@@ -6,6 +6,7 @@ import {
   RunResult,
 } from './ClientInterface';
 import { parse } from 'flatted';
+import { SerializedReactDiagram } from '../types';
 
 export class APIClient implements ClientInterface {
   public root = 'http://localhost:3000'; // https://data-story-server.herokuapp.com
@@ -37,7 +38,7 @@ export class APIClient implements ClientInterface {
     return response.data as RunResult;
   }
 
-  load(name: string): string {
+  load(name: string): SerializedReactDiagram {
     throw 'Not implemented';
   }
 

--- a/src/clients/ClientInterface.ts
+++ b/src/clients/ClientInterface.ts
@@ -2,6 +2,7 @@ import { DiagramModel } from '../diagram/models';
 import {
   BootPayload,
   SerializedReactDiagram,
+  Story,
 } from '../types';
 
 export interface RunResult {
@@ -11,6 +12,6 @@ export interface RunResult {
 export interface ClientInterface {
   boot(options: object): Promise<BootPayload>;
   run(model: DiagramModel): Promise<RunResult>;
-  save(name: string, model: DiagramModel): Promise<any>;
+  save(story: Story): Promise<any>;
   load(name: string): SerializedReactDiagram;
 }

--- a/src/clients/ClientInterface.ts
+++ b/src/clients/ClientInterface.ts
@@ -1,5 +1,8 @@
 import { DiagramModel } from '../diagram/models';
-import { BootPayload } from '../types';
+import {
+  BootPayload,
+  SerializedReactDiagram,
+} from '../types';
 
 export interface RunResult {
   diagram: DiagramModel;
@@ -9,5 +12,5 @@ export interface ClientInterface {
   boot(options: object): Promise<BootPayload>;
   run(model: DiagramModel): Promise<RunResult>;
   save(name: string, model: DiagramModel): Promise<any>;
-  load(name: string): string;
+  load(name: string): SerializedReactDiagram;
 }

--- a/src/clients/local/LocalClient.ts
+++ b/src/clients/local/LocalClient.ts
@@ -6,7 +6,7 @@ import {
 } from '../ClientInterface';
 import context from './localSampleContext';
 import { BootPayload } from '@data-story-org/core';
-import { SerializedReactDiagram } from '../../types';
+import { SerializedReactDiagram, Story } from '../../types';
 
 const server = new LocalServer(context);
 
@@ -25,7 +25,7 @@ export class LocalClient implements ClientInterface {
     return server.load(name);
   }
 
-  save(name: string, model: DiagramModel): Promise<{}> {
-    return server.save(name, model);
+  save(story: Story): Promise<{}> {
+    return server.save(story);
   }
 }

--- a/src/clients/local/LocalClient.ts
+++ b/src/clients/local/LocalClient.ts
@@ -6,6 +6,7 @@ import {
 } from '../ClientInterface';
 import context from './localSampleContext';
 import { BootPayload } from '@data-story-org/core';
+import { SerializedReactDiagram } from '../../types';
 
 const server = new LocalServer(context);
 
@@ -20,7 +21,7 @@ export class LocalClient implements ClientInterface {
     )) as RunResult;
   }
 
-  load(name: string): string {
+  load(name: string): SerializedReactDiagram {
     return server.load(name);
   }
 

--- a/src/clients/local/LocalServer.ts
+++ b/src/clients/local/LocalServer.ts
@@ -1,6 +1,11 @@
-import { Server } from '@data-story-org/core';
+import {
+  Server,
+  DataStory,
+  Diagram,
+} from '@data-story-org/core';
 import { DiagramModel } from '../../diagram/models';
 import { SerializedReactDiagram } from '../../types';
+import { parse, stringify } from 'flatted';
 
 export class LocalServer extends Server {
   boot() {
@@ -12,15 +17,25 @@ export class LocalServer extends Server {
     return bootPayload;
   }
 
-  load(name: string): string {
-    // @ts-ignore
-    return JSON.parse(localStorage.getItem(name));
   load(name: string): SerializedReactDiagram {
+    const story: DataStory<SerializedReactDiagram> = parse(
+      localStorage.getItem(name),
+    );
+    return story.diagram;
   }
 
   async save(name: string, model: DiagramModel) {
-    // @ts-ignore
-    localStorage.setItem(name, model.toJson());
+    localStorage.setItem(
+      name,
+      stringify(
+        new DataStory<SerializedReactDiagram>(
+          name,
+          '',
+          [''],
+          model.serialize(),
+        ),
+      ),
+    );
 
     return new Promise((success) => {
       return success(true);

--- a/src/clients/local/LocalServer.ts
+++ b/src/clients/local/LocalServer.ts
@@ -1,5 +1,6 @@
 import { Server } from '@data-story-org/core';
 import { DiagramModel } from '../../diagram/models';
+import { SerializedReactDiagram } from '../../types';
 
 export class LocalServer extends Server {
   boot() {
@@ -14,6 +15,7 @@ export class LocalServer extends Server {
   load(name: string): string {
     // @ts-ignore
     return JSON.parse(localStorage.getItem(name));
+  load(name: string): SerializedReactDiagram {
   }
 
   async save(name: string, model: DiagramModel) {

--- a/src/clients/local/LocalServer.ts
+++ b/src/clients/local/LocalServer.ts
@@ -1,9 +1,4 @@
-import {
-  Server,
-  DataStory,
-  Diagram,
-} from '@data-story-org/core';
-import { DiagramModel } from '../../diagram/models';
+import { Server, Diagram } from '@data-story-org/core';
 import { SerializedReactDiagram, Story } from '../../types';
 import { parse, stringify } from 'flatted';
 

--- a/src/clients/local/LocalServer.ts
+++ b/src/clients/local/LocalServer.ts
@@ -4,7 +4,7 @@ import {
   Diagram,
 } from '@data-story-org/core';
 import { DiagramModel } from '../../diagram/models';
-import { SerializedReactDiagram } from '../../types';
+import { SerializedReactDiagram, Story } from '../../types';
 import { parse, stringify } from 'flatted';
 
 export class LocalServer extends Server {
@@ -18,24 +18,12 @@ export class LocalServer extends Server {
   }
 
   load(name: string): SerializedReactDiagram {
-    const story: DataStory<SerializedReactDiagram> = parse(
-      localStorage.getItem(name),
-    );
+    const story: Story = parse(localStorage.getItem(name));
     return story.diagram;
   }
 
-  async save(name: string, model: DiagramModel) {
-    localStorage.setItem(
-      name,
-      stringify(
-        new DataStory<SerializedReactDiagram>(
-          name,
-          '',
-          [''],
-          model.serialize(),
-        ),
-      ),
-    );
+  async save(story: Story) {
+    localStorage.setItem(story.name, stringify(story));
 
     return new Promise((success) => {
       return success(true);

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -70,7 +70,7 @@ const App: FC<withLoadingProps> = ({ setLoading }) => {
         console.error('Boot error', error);
         showNotification({
           message: 'Could not Boot! Check console.',
-          type: 'success',
+          type: 'error',
         });
       });
   };

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -22,6 +22,7 @@ import {
 import AppHotkeys from './AppHotkeys';
 import { SerializedReactDiagram } from '../../types';
 import { demos } from '@data-story-org/core';
+import { parse } from 'flatted';
 
 const App: FC<withLoadingProps> = ({ setLoading }) => {
   const store = useStore();
@@ -53,7 +54,12 @@ const App: FC<withLoadingProps> = ({ setLoading }) => {
         store.setAvailableNodes(
           response.data.availableNodes,
         );
-        store.setStories(Cookie.keys());
+
+        store.setStories(
+          Cookie.keys().map((storyName) => {
+            return parse(localStorage.getItem(storyName));
+          }),
+        );
 
         setBooted(true);
         setTimeout(() => {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../utils/isLoadingHOC';
 import AppHotkeys from './AppHotkeys';
 import { SerializedReactDiagram } from '../../types';
-import { Demo, demos } from '@data-story-org/core';
+import { demos } from '@data-story-org/core';
 
 const App: FC<withLoadingProps> = ({ setLoading }) => {
   const store = useStore();

--- a/src/components/controls/ConfigControl.tsx
+++ b/src/components/controls/ConfigControl.tsx
@@ -19,7 +19,6 @@ const ConfigControl: FC<Props> = ({ store }) => {
   };
 
   const closeModal = () => {
-    //this.props.store.diagram.engine.model.setLocked(false);
     setIsOpen(false);
   };
 

--- a/src/components/controls/SaveControl.tsx
+++ b/src/components/controls/SaveControl.tsx
@@ -15,9 +15,6 @@ interface Props {
 const SaveControl: FC<Props> = ({ store }) => {
   const [title, icon] = ['Save story', 'fas fa-save'];
   const [isOpen, setIsOpen] = useState(false);
-  const [defaultStory, setDefaultStory] = useState(
-    store.metadata.activeStory,
-  );
 
   useHotkeys('shift+s', () => {
     onClick();
@@ -45,12 +42,7 @@ const SaveControl: FC<Props> = ({ store }) => {
         onRequestClose={closeModal}
         style={modalStyle}
       >
-        <SaveModal
-          store={store}
-          storyName={defaultStory}
-          setStoryName={setDefaultStory}
-          closeModal={closeModal}
-        />
+        <SaveModal store={store} closeModal={closeModal} />
       </Modal>
     </span>
   );

--- a/src/components/modals/Config/ConfigBody.tsx
+++ b/src/components/modals/Config/ConfigBody.tsx
@@ -29,16 +29,10 @@ const ConfigModalBody: FC = () => {
                 <div
                   className="cursor-pointer hover:text-indigo-600 font-mono"
                   key={server}
-                  onClick={() => {
-                    window.location.href =
-                      window.location.hostname +
-                      '?client=APIClient&server=' +
-                      server;
-                  }}
                 >
                   <li>
                     <a
-                      href="{server}"
+                      href={`?client=APIClient&server=${server}`}
                       className="cursor-pointer hover:text-indigo-600"
                     >
                       {server}

--- a/src/components/modals/Open/Open.tsx
+++ b/src/components/modals/Open/Open.tsx
@@ -6,6 +6,7 @@ import { Store } from '../../../store';
 import OpenModalBody from './OpenBody';
 import OpenModalActions from './OpenActions';
 import BaseModalHeader from '../BaseModalHeader';
+import { loadStory } from '../../../utils';
 
 interface Props {
   store: Store;
@@ -34,23 +35,9 @@ const OpenModal: FC<Props> = ({ store, closeModal }) => {
    * }; */
 
   const clickStory = (name) => {
-    try {
-      const engine = store.diagram.engine;
-      const model = new DiagramModel();
-			const serializedModel = store.metadata.client.load(name)
-			console.log(serializedModel)
-      model.deserializeModel(
-				serializedModel,
-        engine,
-      );
-      engine.setModel(model);
-      closeModal();
-    } catch (e) {
-      alert(
-        `Could not create engine for story ${name}. See console for details.`,
-      );
-      console.error(e);
-    }
+    loadStory(store, name);
+
+    closeModal();
   };
 
   return (

--- a/src/components/modals/Open/OpenBody.tsx
+++ b/src/components/modals/Open/OpenBody.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Store } from '../../../store';
 import { observer } from 'mobx-react-lite';
+import { DataStoryWidget } from '../../widgets/DataStory';
 
 interface Props {
   store: Store;
@@ -11,29 +12,25 @@ const OpenModalBody: FC<Props> = ({
   store,
   clickStory,
 }) => {
-	console.log(store.metadata.demos)
   return (
     <div>
       <div className="w-full bg-gray-100 px-6 py-2">
         <div className="flex flex-col my-4 justify-center align-middle text-gray-500 text-xs">
-					<span className="my-2 font-sans font-medium text-sm text-indigo-500">
-						Your Diagrams
-					</span>
-          <ul>
-            {store.metadata.stories.map((story) => {
+          <span className="my-2 font-sans font-medium text-sm text-indigo-500">
+            Your Diagrams
+          </span>
+          <div className="py-5 grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 gap-5">
+            {store.metadata.stories.map((story, i) => {
               return (
-                <li
-                  className="my-1 hover:text-malibu-500 hover:underline cursor-pointer font-mono"
-                  key={story}
-                  onClick={() => {
-                    clickStory(story);
-                  }}
-                >
-                  {story}
-                </li>
+                <div key={`${i}-${story.name}`}>
+                  <DataStoryWidget
+                    story={story}
+                    storyLoadHandler={clickStory}
+                  />
+                </div>
               );
             })}
-          </ul>				
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/modals/Save/Save.tsx
+++ b/src/components/modals/Save/Save.tsx
@@ -6,7 +6,7 @@ import SaveModalBody from './SaveBody';
 import SaveModalActions from './SaveActions';
 import BaseModalHeader from '../BaseModalHeader';
 import { SaveStoryI } from './SaveStoryI';
-import { DataStory } from '@data-story-org/core';
+import { Story } from '@data-story-org/core';
 import { SerializedReactDiagram } from '../../../types';
 
 interface Props {
@@ -70,7 +70,7 @@ const SaveModal: FC<Props> = ({
   const handleSave = (_e) => {
     store.getModel().clearLinkLabels();
 
-    const dataStory = new DataStory<SerializedReactDiagram>(
+    const dataStory = new Story<SerializedReactDiagram>(
       story.name,
       story.desc,
       Object.values(story.tags),

--- a/src/components/modals/Save/Save.tsx
+++ b/src/components/modals/Save/Save.tsx
@@ -77,6 +77,11 @@ const SaveModal: FC<Props> = ({
       store.getModel().serialize(),
     );
 
+    store.setStories([
+      ...store.metadata.stories,
+      dataStory,
+    ]);
+
     store.metadata.client
       .save(dataStory)
       .then(() => {

--- a/src/components/modals/Save/SaveBody.tsx
+++ b/src/components/modals/Save/SaveBody.tsx
@@ -1,20 +1,66 @@
 import React, { FC } from 'react';
+import { SaveStoryI } from './SaveStoryI';
 
 interface Props {
-  handleChange: (event: any) => void;
+  story: SaveStoryI;
+  handleChange: (
+    field: string,
+    tagKey?: number,
+  ) => (event: any) => void;
+  addTag: (e) => void;
 }
 
-const SaveModalBody: FC<Props> = ({ handleChange }) => {
+const SaveModalBody: FC<Props> = ({
+  story,
+  handleChange,
+  addTag,
+}) => {
   return (
     <div>
-      <div className="w-full bg-gray-100 px-6 py-2">
+      <div className="bg-gray-100 px-6 py-2">
         <div className="flex flex-col my-4 justify-center align-middle text-gray-500 text-xs">
-          <span className="my-2">Name</span>
+          <span className="my-2 font-sans font-medium text-sm text-indigo-500">
+            Name
+          </span>
           <input
-            onChange={handleChange}
-            className="px-2 py-1 rounded font-mono appearance-none focus:outline-none"
-            placeholder="descriptive-name.story"
+            onChange={handleChange('name')}
+            className="w-full px-3 py-2 text-gray-700 border rounded-lg appearance-none focus:outline-none"
+            placeholder="descriptive story name"
+            value={story.name}
           />
+
+          <span className="my-2 font-sans font-medium text-sm text-indigo-500">
+            Description
+          </span>
+          <input
+            onChange={handleChange('desc')}
+            type="textarea"
+            className="w-full px-3 py-2 text-gray-700 border rounded-lg appearance-none focus:outline-none"
+            placeholder="story description"
+            value={story.desc}
+          />
+
+          <span className="my-2 font-sans font-medium text-sm text-indigo-500">
+            Tags
+          </span>
+          <div className="grid-cols-3">
+            {Object.values(story.tags).map((tag, i) => {
+              return (
+                <input
+                  key={i}
+                  onChange={handleChange('tags', i)}
+                  className="rounded-full px-3 py-2 w-1/5 text-gray-700 text-center border appearance-none focus:outline-none"
+                  placeholder="story tags"
+                  value={tag}
+                />
+              );
+            })}
+            <button onClick={addTag}>
+              <span className="m-2 text-sm font-thin">
+                +
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/modals/Save/SaveStoryI.ts
+++ b/src/components/modals/Save/SaveStoryI.ts
@@ -1,0 +1,5 @@
+export interface SaveStoryI {
+  name: string;
+  desc: string;
+  tags: { [key: number]: string };
+}

--- a/src/components/pages/Splash.tsx
+++ b/src/components/pages/Splash.tsx
@@ -1,28 +1,22 @@
 import React, { FC } from 'react';
 import { observer } from 'mobx-react-lite';
 import { Store } from '../../store';
-import { DiagramModel } from '../../diagram/models';
 import { DataStoryWidget } from '../widgets/DataStory';
+import { loadDemo, loadStory } from '../../utils';
 
 interface Props {
   store: Store;
 }
 
 const Splash: FC<Props> = ({ store }) => {
-  const onClick = (name: string) => {
-    try {
-      const engine = store.diagram.engine;
-      const model = new DiagramModel();
+  const onClickDemo = (name: string) => {
+    loadDemo(store, name);
+    store.setPage('Workbench');
+  };
 
-      engine.setModel(model);
-      store.importDemo(name);
-      store.setPage('Workbench');
-    } catch (e) {
-      alert(
-        `Could not create engine for demo ${name}. See console for details.`,
-      );
-      console.error(e);
-    }
+  const onClickSaved = (name: string) => {
+    loadStory(store, name);
+    store.setPage('Workbench');
   };
 
   return (

--- a/src/components/pages/Splash.tsx
+++ b/src/components/pages/Splash.tsx
@@ -2,57 +2,48 @@ import React, { FC } from 'react';
 import { observer } from 'mobx-react-lite';
 import { Store } from '../../store';
 import { DiagramModel } from '../../diagram/models';
+import { DataStoryWidget } from '../widgets/DataStory';
 
 interface Props {
   store: Store;
 }
 
 const Splash: FC<Props> = ({ store }) => {
-	const onClick = (name: string) => {
+  const onClick = (name: string) => {
     try {
       const engine = store.diagram.engine;
       const model = new DiagramModel();
-			engine.setModel(model);
-			store.importDemo(name)
-      store.setPage('Workbench')
+
+      engine.setModel(model);
+      store.importDemo(name);
+      store.setPage('Workbench');
     } catch (e) {
       alert(
         `Could not create engine for demo ${name}. See console for details.`,
       );
       console.error(e);
     }
-	}
+  };
 
   return (
-<div className="h-screen">
-<div className="pt-5 bg-gray-600 text-gray-300 items-center text-lg font-black flex justify-around">Quick start:</div>
-	<div className="px-10 py-5 bg-gray-600  grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 gap-5">	
-		{store.metadata.demos.map(demo => {
-			return (
-				<div 
-					key={demo.name}
-					className="cursor-pointer rounded bg-gray-400 hover:shadow-xl overflow-hidden shadow-lg"
-					onClick={() => onClick(demo.name)}
-				>
-					<div className="px-6 py-4">
-						<div className="font-bold text-xl mb-2">{demo.name}</div>
-						<p className="text-gray-700 text-base">
-							{(demo as any).description}
-						</p>
-					</div>
-					<div className="px-6 pt-4 pb-2">
-						{demo.tags.map((tag: string) => {
-							return (
-								<span key={tag} className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">{tag}</span>
-							)
-						})}
-					</div>
-    		</div>
-			)})
-		}			
-  </div>
-</div>
+    <div className="h-screen">
+      <div className="pt-5 bg-gray-600 text-gray-300 items-center text-lg font-black flex justify-around">
+        Quick start:
+      </div>
+      <div className="px-10 py-5 bg-gray-600  grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 gap-5">
+        {store.metadata.demos.map((demo, i) => {
+          return (
+            <div key={`i-${demo.name}`}>
+              <DataStoryWidget
+                story={demo}
+                storyLoadHandler={onClick}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
-}
+};
 
 export default observer(Splash);

--- a/src/components/pages/Splash.tsx
+++ b/src/components/pages/Splash.tsx
@@ -9,6 +9,9 @@ interface Props {
 }
 
 const Splash: FC<Props> = ({ store }) => {
+  const userHaveStories =
+    store.metadata.stories.length !== 0;
+
   const onClickDemo = (name: string) => {
     loadDemo(store, name);
     store.setPage('Workbench');
@@ -27,15 +30,36 @@ const Splash: FC<Props> = ({ store }) => {
       <div className="px-10 py-5 bg-gray-600  grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 gap-5">
         {store.metadata.demos.map((demo, i) => {
           return (
-            <div key={`i-${demo.name}`}>
+            <div key={`${i}-${demo.name}`}>
               <DataStoryWidget
                 story={demo}
-                storyLoadHandler={onClick}
+                storyLoadHandler={onClickDemo}
               />
             </div>
           );
         })}
       </div>
+
+      {userHaveStories ? (
+        <>
+          <div className="pt-5 bg-gray-600 text-gray-300 items-center text-lg font-black flex justify-around">
+            Your stories:
+          </div>
+
+          <div className="px-10 py-5 bg-gray-600  grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3 gap-5">
+            {store.metadata.stories.map((story, i) => {
+              return (
+                <div key={`${i}-${story.name}`}>
+                  <DataStoryWidget
+                    story={story}
+                    storyLoadHandler={onClickSaved}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 };

--- a/src/components/widgets/DataStory/DataStory.tsx
+++ b/src/components/widgets/DataStory/DataStory.tsx
@@ -1,8 +1,10 @@
 import React, { FC } from 'react';
-import { DataStory } from '@data-story-org/core';
+import { Story as DefaultStory } from '@data-story-org/core';
 import { SerializedReactDiagram } from '../../../types';
 
-type Story = DataStory<SerializedReactDiagram> | DataStory;
+type Story =
+  | DefaultStory<SerializedReactDiagram>
+  | DefaultStory;
 
 interface Props {
   story: Story;

--- a/src/components/widgets/DataStory/DataStory.tsx
+++ b/src/components/widgets/DataStory/DataStory.tsx
@@ -1,8 +1,11 @@
 import React, { FC } from 'react';
 import { DataStory } from '@data-story-org/core';
+import { SerializedReactDiagram } from '../../../types';
+
+type Story = DataStory<SerializedReactDiagram> | DataStory;
 
 interface Props {
-  story: DataStory;
+  story: Story;
   storyLoadHandler: (storyName: string) => void;
 }
 
@@ -17,7 +20,7 @@ export const DataStoryWidget: FC<Props> = ({
       onClick={() => storyLoadHandler(story.name)}
     >
       <div className="px-6 py-4">
-        <div className="font-bold text-xl mb-2">
+        <div className="text-black font-bold text-xl mb-2">
           {story.name}
         </div>
         <p className="text-gray-700 text-base">
@@ -26,14 +29,14 @@ export const DataStoryWidget: FC<Props> = ({
       </div>
       <div className="px-6 pt-4 pb-2">
         {story.tags.map((tag: string) => {
-          return (
+          return tag ? (
             <span
               key={tag}
               className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"
             >
               {tag}
             </span>
-          );
+          ) : null;
         })}
       </div>
     </div>

--- a/src/components/widgets/DataStory/DataStory.tsx
+++ b/src/components/widgets/DataStory/DataStory.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react';
+import { DataStory } from '@data-story-org/core';
+
+interface Props {
+  story: DataStory;
+  storyLoadHandler: (storyName: string) => void;
+}
+
+export const DataStoryWidget: FC<Props> = ({
+  story,
+  storyLoadHandler,
+}) => {
+  return (
+    <div
+      key={story.name}
+      className="cursor-pointer rounded bg-gray-400 hover:shadow-xl overflow-hidden shadow-lg"
+      onClick={() => storyLoadHandler(story.name)}
+    >
+      <div className="px-6 py-4">
+        <div className="font-bold text-xl mb-2">
+          {story.name}
+        </div>
+        <p className="text-gray-700 text-base">
+          {story.description}
+        </p>
+      </div>
+      <div className="px-6 pt-4 pb-2">
+        {story.tags.map((tag: string) => {
+          return (
+            <span
+              key={tag}
+              className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"
+            >
+              {tag}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/widgets/DataStory/index.ts
+++ b/src/components/widgets/DataStory/index.ts
@@ -1,0 +1,1 @@
+export * from './DataStory';

--- a/src/diagram/models/DiagramModel.ts
+++ b/src/diagram/models/DiagramModel.ts
@@ -5,6 +5,7 @@ import {
 import { NodeModel } from './NodeModel';
 import { SerializedReactDiagram } from '../../types';
 import VERSION from '../../utils/version';
+import { stringify } from 'flatted';
 
 /**
  * Sorts model in execution order based on their dependencies
@@ -26,11 +27,7 @@ export class DiagramModel extends DefaultDiagramModel {
   }
 
   toJson(indentation = 0): string {
-    return JSON.stringify(
-      this.serialize(),
-      null,
-      indentation,
-    );
+    return stringify(this.serialize(), null, indentation);
   }
 
   toPrettyJson(): string {

--- a/src/diagram/models/DiagramModel.ts
+++ b/src/diagram/models/DiagramModel.ts
@@ -31,7 +31,7 @@ export class DiagramModel extends DefaultDiagramModel {
   }
 
   toPrettyJson(): string {
-    return this.toJson(4);
+    return JSON.stringify(this.serialize(), null, 4);
   }
 
   serialize(): SerializedReactDiagram {

--- a/src/store/RootStore.ts
+++ b/src/store/RootStore.ts
@@ -1,7 +1,12 @@
 import { action, observable, makeObservable } from 'mobx';
 import { Client, ClientFactory } from '../clients';
 import { showNotification } from '../utils/Notifications';
-import { Page, Inspector, InspectorMode } from '../types';
+import {
+  Page,
+  Inspector,
+  InspectorMode,
+  SerializedReactDiagram,
+} from '../types';
 import { DiagramEngine } from '@projectstorm/react-diagrams';
 import { DiagramModel, NodeModel } from '../diagram/models';
 import {
@@ -16,7 +21,7 @@ interface Metadata {
   page: Page;
   activeInspector: Inspector;
   requestOpenNodeModal: string;
-  stories: any[];
+  stories: DataStory<SerializedReactDiagram>[];
   activeStory: string;
   client: Client;
   demos: DataStory[];

--- a/src/store/RootStore.ts
+++ b/src/store/RootStore.ts
@@ -10,7 +10,7 @@ import {
 import { DiagramEngine } from '@projectstorm/react-diagrams';
 import { DiagramModel, NodeModel } from '../diagram/models';
 import {
-  DataStory,
+  Story,
   demos,
   Node as HeadlessNode,
 } from '@data-story-org/core';
@@ -21,10 +21,10 @@ interface Metadata {
   page: Page;
   activeInspector: Inspector;
   requestOpenNodeModal: string;
-  stories: DataStory<SerializedReactDiagram>[];
+  stories: Story<SerializedReactDiagram>[];
   activeStory: string;
   client: Client;
-  demos: DataStory[];
+  demos: Story[];
 }
 
 interface Diagram {
@@ -96,7 +96,7 @@ export class Store {
     });
   }
 
-  addDemos(demos: DataStory[]) {
+  addDemos(demos: Story[]) {
     this.metadata.demos = demos;
   }
 

--- a/src/store/RootStore.ts
+++ b/src/store/RootStore.ts
@@ -5,7 +5,7 @@ import { Page, Inspector, InspectorMode } from '../types';
 import { DiagramEngine } from '@projectstorm/react-diagrams';
 import { DiagramModel, NodeModel } from '../diagram/models';
 import {
-  Demo,
+  DataStory,
   demos,
   Node as HeadlessNode,
 } from '@data-story-org/core';
@@ -19,7 +19,7 @@ interface Metadata {
   stories: any[];
   activeStory: string;
   client: Client;
-  demos: Demo[];
+  demos: DataStory[];
 }
 
 interface Diagram {
@@ -91,7 +91,7 @@ export class Store {
     });
   }
 
-  addDemos(demos: Demo[]) {
+  addDemos(demos: DataStory[]) {
     this.metadata.demos = demos;
   }
 

--- a/src/types/DataStory.ts
+++ b/src/types/DataStory.ts
@@ -1,4 +1,4 @@
-import { DataStory as DefaultStory } from '@data-story-org/core';
+import { Story as DefaultStory } from '@data-story-org/core';
 import { SerializedReactDiagram } from './SerializedReactDiagram';
 
 export type Story = DefaultStory<SerializedReactDiagram>;

--- a/src/types/DataStory.ts
+++ b/src/types/DataStory.ts
@@ -1,0 +1,4 @@
+import { DataStory as DefaultStory } from '@data-story-org/core';
+import { SerializedReactDiagram } from './SerializedReactDiagram';
+
+export type Story = DefaultStory<SerializedReactDiagram>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,4 @@ export {
 export { SerializedNodeModel } from './SerializedNodeModel';
 export { SerializedReactDiagram } from './SerializedReactDiagram';
 export { BootPayload } from './BootPayload';
+export * from './DataStory';

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,1 +1,2 @@
 export { renameKey } from './helpers';
+export * from './stories';

--- a/src/utils/stories.ts
+++ b/src/utils/stories.ts
@@ -1,0 +1,42 @@
+import { DiagramModel } from '../diagram/models';
+import { Store } from '../store';
+
+export const loadStory = (
+  store: Store,
+  storyName: string,
+) => {
+  try {
+    const engine = store.diagram.engine;
+    const model = new DiagramModel();
+    const serializedModel =
+      store.metadata.client.load(storyName);
+
+    console.log(serializedModel);
+
+    model.deserializeModel(serializedModel, engine);
+    engine.setModel(model);
+  } catch (e) {
+    alert(
+      `Could not create engine for story ${storyName}. See console for details.`,
+    );
+    console.error(e);
+  }
+};
+
+export const loadDemo = (
+  store: Store,
+  demoName: string,
+) => {
+  try {
+    const engine = store.diagram.engine;
+    const model = new DiagramModel();
+
+    engine.setModel(model);
+    store.importDemo(demoName);
+  } catch (e) {
+    alert(
+      `Could not create engine for demo ${demoName}. See console for details.`,
+    );
+    console.error(e);
+  }
+};


### PR DESCRIPTION
# Prerequisites

New DataStory type gives us ability to create, save, load stories in format that holds stories metadata. 


# Changes


## DataStory widget

Since now Demos are of the same DataStory type as stories themselves, we can add a new component for displaying story widgets. It can be used not for just showing demos on the splash screen, but user created stories. So user stories will be displayed like on the screenshots

![2021-09-21_23-08-41](https://user-images.githubusercontent.com/49302467/134244195-1135c860-74f9-45e5-b556-748fb308c3de.png)
![2021-09-21_23-11-52](https://user-images.githubusercontent.com/49302467/134244207-551b3516-ce5a-4639-a7a1-077e8fc407c8.png)



## Story saving

-   handling of new stories fields
-   automatic adding of saved story to store *(so extra page refreshing to trigger boot is not required)*
-   ClientInterface save method now takes DataStory parameter
-   stories are being held in new DataStory type with extra metadata *(so in future fuzzy-search over descriptions, tags, names can be easily added)*
-   for stringifying flatted library is used *(needed for better future integration with node-server when implementing save and load methods)*


## ConfigControl

Previously there were some problems like double redirects and unneeded onClick handler, so some bugs happened especially on chromium browsers. Now all must work as expected


## Backward compatibility

Because of new type in what the stories are stored, and that they are stringified using flatted to deal with circular JSON it&rsquo;s required to clean localStorage (loading diagrams stringified using default JSON library, and stored just as is without any metadata will lead us to errors)


# Example of new stories widget for user-saved stories
![2021-09-21-23:23:59](https://user-images.githubusercontent.com/49302467/134244305-63fe1b8e-fd9c-4056-a19f-ecff28a9c516.gif)
