### PR TITLE
NodeSearch styles updates, always available search input

### DIFF
--- a/src/components/controls/AddNodeControl.tsx
+++ b/src/components/controls/AddNodeControl.tsx
@@ -11,6 +11,7 @@ const customStyles = {
     maxWidth: '450px',
     top: '110px',
     left: '120px',
+    padding: '0.25rem',
     //top                   : '25%',
     //left                  : '25%',
     //right                 : 'auto',

--- a/src/components/controls/NodeSearch/NodeListItem.tsx
+++ b/src/components/controls/NodeSearch/NodeListItem.tsx
@@ -27,7 +27,9 @@ export const NodeListItem: FC<Props> = ({
       }}
       {...elementDataProperties}
       className={`py-3 flex ${
-        selected == true ? 'shadow-2xl' : 'opacity-50'
+        selected === true
+          ? 'shadow-2xl saturate-100'
+          : 'opacity-40 shadow-2xl shadow-inner hue-rotate-60'
       }`}
       tabIndex={2}
     >

--- a/src/components/controls/NodeSearch/NodeSearch.tsx
+++ b/src/components/controls/NodeSearch/NodeSearch.tsx
@@ -19,7 +19,6 @@ interface Props {
 const NodeSearch: FC<Props> = ({ store, onFinish }) => {
   const [search, setSearch] = useState('');
   const [cursor, setCursor] = useState(0);
-
   const nameInput = useRef(null);
   const currentSearch = useRef(null);
 
@@ -38,7 +37,12 @@ const NodeSearch: FC<Props> = ({ store, onFinish }) => {
       ? setCursor(cursor + 1)
       : setCursor(0);
 
-    currentSearch.current.scrollIntoView();
+    currentSearch.current.scrollIntoView(false, {
+      block: 'center',
+      inline: 'center',
+    });
+
+    nameInput.current.focus();
   };
 
   const goUp = () => {
@@ -46,7 +50,12 @@ const NodeSearch: FC<Props> = ({ store, onFinish }) => {
       ? setCursor(cursor - 1)
       : setCursor(filteredNodes.length - 1);
 
-    currentSearch.current.scrollIntoView();
+    currentSearch.current.scrollIntoView(false, {
+      block: 'center',
+      inline: 'center',
+    });
+
+    nameInput.current.focus();
   };
 
   useHotkeys(

--- a/src/components/controls/NodeSearch/NodeSearch.tsx
+++ b/src/components/controls/NodeSearch/NodeSearch.tsx
@@ -135,7 +135,7 @@ const NodeSearch: FC<Props> = ({ store, onFinish }) => {
           onChange={searchChange}
           type="text"
           ref={nameInput}
-          className="w-full p-2 rounded appearance-none focus:outline-none focus:bg-white"
+          className="w-full p-2 rounded appearance-none focus:outline-none focus:bg-white font-medium tracking-tighter antialiased"
           placeholder="model | method | reader | writer ..."
           tabIndex={1}
         />

--- a/src/components/controls/NodeSearch/NodeSearch.tsx
+++ b/src/components/controls/NodeSearch/NodeSearch.tsx
@@ -117,8 +117,8 @@ const NodeSearch: FC<Props> = ({ store, onFinish }) => {
   };
 
   return (
-    <div className="flex flex-col bg-gray-100 -m-5 rounded shadow max-w-xl text-xs">
-      <div className="bg-white shadow p-4">
+    <div className="flex flex-col bg-gray-100 rounded shadow max-w-full text-sm">
+      <div className="sticky top-0 z-50 bg-white shadow p-4 m-1">
         <input
           autoComplete="off"
           id="node-search"


### PR DESCRIPTION
# Updates

-   padding is being configured by inline styles instead of tailwind negative margins
-   little updates to styles
-   always available search input


# Comparison of styles

current / previous

![2021-09-24_21-51-32](https://user-images.githubusercontent.com/49302467/134726104-47e2c7ed-9763-4777-8354-94154e3e88ad.png)




# Example of always available search

![2021-09-24-21:39:26](https://user-images.githubusercontent.com/49302467/134726079-5ee99e49-1ff8-4a43-abcd-4af60640247a.gif)
