### PR TITLE
Fix placeholders for Rows

### DIFF
--- a/src/components/fields/Row.tsx
+++ b/src/components/fields/Row.tsx
@@ -33,12 +33,7 @@ export const Row: FC<Props> = ({
           return (
             <div key={`field-${p.name}-${i}`}>
               <Field
-                options={
-                  {
-                    ...options,
-                    value: p.value,
-                  } as NodeParameter
-                }
+                options={p}
                 handleChange={handleRowChange(p)}
               />
             </div>


### PR DESCRIPTION
# Changes

Instead of passing the row options, now fields will receive the right options of underlying parameters.

# Examples

Here's example of RenameAttributes node without explicit values but with placeholders

![2021-10-03_16-41-48](https://user-images.githubusercontent.com/49302467/135756171-1a7763bd-243f-485b-921f-5d53e76fe20d.png)
