### PR TITLE
Publishing fixes

### DIFF
--- a/configs/tailwind.config.js
+++ b/configs/tailwind.config.js
@@ -11,9 +11,13 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['IBM Plex Sans'],
-        serif: ['IBM Plex Serif'],
-        mono: ['IBM Plex Mono'],
+        // Remove font settings so they
+        // won't be forced globally,
+        // and therefore gui can be used
+        // as widget in other apps
+        sans: [''],
+        serif: [''],
+        mono: [''],
       },
       colors: {
         malibu: {

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -13,6 +13,21 @@
   text-align: initial;
   margin: initial;
   background-color: initial;
+$font-sans: IBM Plex Sans;
+$font-mono: IBM Plex Mono;
+
+.font-sans {
+  font-family: $font-sans;
+}
+
+.font-mono {
+  font-family: $font-mono;
+}
+
+#data-story-gui,
+.ReactModalPortal {
+  @extend .no-scrollbar;
+  @extend .font-sans;
 }
 
 // React Diagrams must have explicit width and height

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -13,6 +13,10 @@
   text-align: initial;
   margin: initial;
   background-color: initial;
+
+  position: relative;
+}
+
 $font-sans: IBM Plex Sans;
 $font-mono: IBM Plex Mono;
 

--- a/src/sections/App/App.tsx
+++ b/src/sections/App/App.tsx
@@ -86,7 +86,16 @@ export const App: FC<withLoadingProps> = withLoading(
         <Header store={store} />
         <Toolbar store={store} setLoading={setLoading} />
         {booted && <Page store={store} />}
-        <ToastContainer style={{ paddingTop: '0px' }} />
+        <ToastContainer
+          style={{
+            position: 'absolute',
+            bottom: '2%',
+            right: '2%',
+            overflow: 'hidden',
+            zIndex: 0,
+            padding: '1em',
+          }}
+        />
         <AppHotkeys store={store} />
       </div>
     );


### PR DESCRIPTION
# Updates


## Fonts

Tailwind default fonts settings removed, and being set in the app css instead. So font&rsquo;s used in gui won&rsquo;t be forced globally but just for the DataStory component


## Notifications

Notifications container now placed in frame of app, relatively to DataStory widget instead of whole browser page. Therefore notifications sent by data-story can be easily distinguished from global ones

![2021-11-08_17-46-34](https://user-images.githubusercontent.com/49302467/140802100-4f0384eb-bf04-4a13-a9a0-de7911207c8e.png)
