### PR TITLE
Set default inspector if not set

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,9 @@ See [contributing](contributing.md) for setuping seamless development environmen
 | Hotkey   |       Action       |
 | -------- | :----------------: |
 | ALT+D    |   Go to diagram    |
+| ALT+I    | Go to Inspectors   |
 | ALT+J    | Go to diagram JSON |
+| ALT+O    |    open            |
 | ALT+PLUS |      Add node      |
 | ALT+R    |    Run diagram     |
+| ALT+S    |    save            |

--- a/src/lib/store/RootStore.ts
+++ b/src/lib/store/RootStore.ts
@@ -172,7 +172,7 @@ export class Store {
   setPage(name) {
     const alreadyOnPage = this.metadata.page == name;
     this.metadata.page =
-      alreadyOnPage && name !== 'Inspector'
+      alreadyOnPage
         ? 'Workbench'
         : name;
   }

--- a/src/sections/App/AppHotkeys.tsx
+++ b/src/sections/App/AppHotkeys.tsx
@@ -14,7 +14,14 @@ export const AppHotkeys: FC<Props> = observer(
       store.setPage('Workbench');
     });
 
-    useHotkeys('shift+t', () => {
+    useHotkeys('shift+i', () => {
+			if(!store.metadata.activeInspector.nodeId) {
+				const inspectables = store.nodesWithInspectables()
+				store.setActiveInspector(
+					inspectables.length ? inspectables[0].id : null
+				)
+			}
+
       store.setPage('Inspector');
     });
 

--- a/tests/Browser/Hotkeys.e2e.test.ts
+++ b/tests/Browser/Hotkeys.e2e.test.ts
@@ -90,7 +90,7 @@ describe('Hotkeys', () => {
   test('[SHIFT + D] opens diagram', async () => {
     // Go to inpector first
     await page.keyboard.down('Shift');
-    await page.keyboard.press('KeyT');
+    await page.keyboard.press('KeyI');
     await page.keyboard.up('Shift');
     await expect(page).toMatch('No data to show here');
 

--- a/tests/Browser/Hotkeys.e2e.test.ts
+++ b/tests/Browser/Hotkeys.e2e.test.ts
@@ -53,9 +53,9 @@ describe('Hotkeys', () => {
     await expect(page).toMatch('node_name');
   }, 100000);
 
-  test('[SHIFT + T] opens inspector', async () => {
+  test('[SHIFT + I] opens inspector', async () => {
     await page.keyboard.down('Shift');
-    await page.keyboard.press('KeyT');
+    await page.keyboard.press('KeyI');
     await page.keyboard.up('Shift');
 
     await expect(page).toMatch('No data to show here');


### PR DESCRIPTION
* Changes hotkey to inspectors to `SHIFT+i`.
* Repeated hotkey usage will toggle back to diagram.
* If the the hotkey was used without having an activeInspector set, it will default to the first it can find.
